### PR TITLE
Adding @font-feature-values

### DIFF
--- a/css-font-display/index.bs
+++ b/css-font-display/index.bs
@@ -80,10 +80,10 @@ Design/performance-conscious web developers have a good sense for the relative i
 This specification provides them the ability to control font timeout and rendering behavior.
 Specifically, it lets developers:
 
-* Define the font rendering strategy when text is ready to be painted: block, or paint with fallback.
-* Define the font rendering behavior once the desired font is available: rerender text with the new font, or leave it with the fallback.
+* Define the font display policy when text is ready to be painted: block, or paint with fallback.
+* Define the font display policy once the desired font is available: rerender text with the new font, or leave it with the fallback.
 * Define custom timeout values for each font.
-* Define custom render and timeout strategies per element.
+* Define custom display and timeout policies per element.
 
 The Font Display Timeline {#timeline}
 =====================================
@@ -159,9 +159,9 @@ for example, forcing all fonts to have a ''0s'' <a>block period</a>.
 <dl dfn-type="value" dfn-for="@font-face/font-display">
 	<dt><dfn>auto</dfn>
 	<dd>
-		The font display strategy is user-agent-defined.
+		The font display policy is user-agent-defined.
 
-		Note: Many browsers have a default strategy similar to that specified by ''block''.
+		Note: Many browsers have a default policy similar to that specified by ''block''.
 
 	<dt><dfn>block</dfn>
 	<dd>
@@ -279,11 +279,12 @@ for example, forcing all fonts to have a ''0s'' <a>block period</a>.
 
 Controlling Font Display Per Font-Family via ''@font-feature-values''
 ===========================
-The '@font-feature-values/font-display' descriptor for ''@font-feature-values''
-determines how a font family is displayed, by setting the "default" font-display value for @font-face rules targeting the same font family.
-In other words, @font-feature-values/font-display will set the value of "font-display:auto" (and its omission) for the @font-face rules of a given font-family.
+The '@font-feature-values/font-display' descriptor for ''@font-feature-values'' determines how a font family is displayed, by setting the "default" font-display value for @font-face rules targeting the same font family.
+When font-display is omitted in an @font-face rule, the user agent uses the font-display value set via the @font-feature-values/font-display for the relevant font-family if one is set, and otherwise defaults to "font-display: auto".
 
-This can be used to avoid the ransom note effect (i.e. "different loading behavior on different parts of the page") and to customize third party served fonts for which the modification of @font-face rules is not always possible.
+This mechanism can be used to set a default display policy for an entire font-family, and enables developers to set a display policy for @font-face rules that are not directly under their control.
+For example, when a font is served by a third-party font foundry, the developer does not control the @font-face rules but is still able to set a default font-display policy for the provided font-family.
+The ability to set a default policy for an entire font-family is also useful to avoid the ransom note effect (i.e. mismatched font faces) because the display policy is then applied to the entire font family.
 
 <pre class='descdef'>
 Name: font-display

--- a/css-font-display/index.bs
+++ b/css-font-display/index.bs
@@ -131,6 +131,7 @@ Issue: ''fallback'' and ''optional'' can result in some faces in a family being 
 while others are required to fallback,
 giving a "ransom note" look.
 Perhaps require that all fonts in a family have the same behavior (all swapped in, or all fallback)?
+See also the @font-feature-values for controlling the behavior on a font family basis.
 
 
 Controlling Font Display Per Font-Face: the ''@font-face/font-display'' descriptor {#font-display-desc}
@@ -275,6 +276,21 @@ for example, forcing all fonts to have a ''0s'' <a>block period</a>.
 			rather than quitting and going elsewhere because the site takes too long to load.
 		</div>
 </dl>
+
+Controlling Font Display Per Font-Family via ''@font-feature-values''
+===========================
+The '@font-feature-values/font-display' descriptor for ''@font-feature-values''
+determines how a font family is displayed, by setting the "default" font-display value for @font-face rules targeting the same font family.
+In other words, @font-feature-values/font-display will set the value of "font-display:auto" (and its omission) for the @font-face rules of a given font-family.
+
+This can be used to avoid the ransom note effect (i.e. "different loading behavior on different parts of the page") and to customize third party served fonts for which the modification of @font-face rules is not always possible.
+
+<pre class='descdef'>
+Name: font-display
+Value: auto | block | swap | fallback | optional
+Initial: auto
+For: @font-feature-values
+</pre>
 
 <div class='issue'>
 	These names aren't great.


### PR DESCRIPTION
Trying to add @font-feature-values to the spec based on insights gained from experimenting with the @font-face/font-display descriptor and third party served web fonts.

Tab, does this look reasonable?
Should I expand with examples and details about what this would mean for the user agent?
Examples:

```
<link rel="https://fonts.googleapis.com/css?family=Roboto" rel="stylesheet">
<style>
@font-feature-values Roboto {
 font-display: optional;
}
</style>
```

Optional is set on a font-family with no refinement in individual font-face.
- The UA only use the font family if _all_ the required font-face are readily available
- otherwise the UA would just use the fallback font.
# 

```
<style>
@font-face {
  font-family: 'Roboto';
  font-style: normal;
  font-weight: 400;
  src: local('Roboto'), local('Roboto-Regular'), url(/roboto/regular.woff2) format('woff2');
}

@font-face {
  font-family: 'Roboto';
  font-style: normal;
  font-weight: 700;
  src: local('Roboto Bold'), local('Roboto-Bold'), url(/roboto/bold.woff2) format('woff2');
}

@font-face {
  font-family: 'Roboto';
  font-display: block;
  font-style: italic;
  font-weight: 400;
  src: local('Roboto Italic'), local('Roboto-Italic'), url(/roboto/italic.woff2) format('woff2');
}

@font-feature-values Roboto {
 font-display: fallback;
}
</style>
```

font-display: fallback is set on a font-family with refinement in some individual font-face rules:
-  The UA only use the font family if the regular and bold font-face are quickly available, otherwise the UA would just start with the fallback font and stick with it if too much time passes.
- On the other hand, the UA will block on the italic font face because its font-display descriptor trumps the default set by @font-feature-values.
